### PR TITLE
Relax requirements to include 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Create British National Grid-based spatial indexes."
 authors = ["Dan Lewis <daniel.lewis@defra.gov.uk>", "Ed Fawcett-Taylor <ed.fawcett-taylor@defra.gov.uk>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
 Shapely = "^1.8.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Hi Ed,

Do you foresee any issues with relaxing the py version constraint to `3.7`?

One of the databricks clusters we are working on only has `py3.7` available and this library you've made seems super useful... For now, I have just installed it from a fork where I have relaxed the constraint. I would prefer not to have to do this though.

I've run the tests in a `py3.7` environment with no errors.

```
(bng-indexer-BUCPYpjK-py3.7 ) > pytest -q
....................................................................                                                                                                                                                           [100%]
68 passed in 0.40s
```